### PR TITLE
docs(readme): fix typo on firebase token gen

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 4. Get your Firebase token from CLI:
 ```bash
-npx firebase login:ci
+npx firebase-tools login:ci
 ```
 ```bash
 # OR with firebase-tools installed globally


### PR DESCRIPTION
Changing lib from `firebase` to `firebase-tools` on npx command.